### PR TITLE
remove slider if if there is no featured album name set

### DIFF
--- a/theme/album.hbs
+++ b/theme/album.hbs
@@ -64,7 +64,12 @@
 
     {{#if album.home}}
       <script id="slider-js" data-interval="{{@root.settings.sliderInterval}}">
+        const rootAlbumName = "{{@root.settings.featuredAlbum}}";
         $(document).ready(function () {
+          if (!rootAlbumName) {
+            $('#lightSlider').remove();
+            return;
+          }
           let waitTime = 1000;
 
           try {


### PR DESCRIPTION
i have only one gallery (so album.home = true) but do not want to show a featured album. without this patch an empty slider div with a height is created and pushes the imgs down the page

